### PR TITLE
Fix importing base settings into production settings

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,0 +1,1 @@
+from .base import *


### PR DESCRIPTION
My plan is to consolidate these settings files in the future and just use environment variables to drive the difference in configs.

For now this retains the logic of using different files for each environment but the production version just happens to be identical to the base settings after my last set of changes.